### PR TITLE
Update template to support iPython >= 2

### DIFF
--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -4,7 +4,12 @@
 # Base16 Prompt Toolkit template by Carlos Pita (carlosjosepita@gmail.com
 # {{scheme-name}} scheme by {{scheme-author}}
 
-from prompt_toolkit.terminal.vt100_output import _256_colors
+try:
+  # older than v2
+  from prompt_toolkit.terminal.vt100_output import _256_colors
+except ModuleNotFoundError:
+  # version 2
+  from prompt_toolkit.formatted_text.ansi import _256_colors
 from pygments.style import Style
 from pygments.token import (Keyword, Name, Comment, String, Error, Text,
                             Number, Operator, Literal, Token)


### PR DESCRIPTION
I noticed this wasn't working for the latest version of iPython.
Turns they moved the color map. I was surprised I didn't need to change anything else.
Anyway, this seems to work quite nicely.

I don't know how to run the template over all the colors, but was able to manually test it by updating the base16-ocean theme locally with the adjusted `import` statement.

Here's what it looks like in my terminal:
![image](https://user-images.githubusercontent.com/1975119/56752659-66b8ae00-674e-11e9-9d35-470ffdccc245.png)

Thanks for the initial work!